### PR TITLE
Adds Clojure pipe code

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,5 +71,6 @@ But there is r2pipe for:
 	Rust        x     x     -    -    -   -    x    -
 	Swift       x     x     x    x    -   -    x    -
 	Vala        -     x     x    -    -   -    -    -
+    Clojure     x     x     -    -    -   -    -    -
 
 --pancake

--- a/clojure/README.md
+++ b/clojure/README.md
@@ -1,0 +1,33 @@
+# r2pipe.clj
+
+`"Know only Clojure and want to work with r2? I got you fam."`
+
+r2pipe.clj is a Clojure library to interact with [radare2](https://github.com/radare/radare2). This requires you to have r2 installed on your system. It spawns a new process and communicates with it over pipes.
+
+## Installation
+
+In Leiningen:
+
+[![Clojars Project](https://img.shields.io/clojars/v/org.clojars.chinmay_dd/r2pipe.svg)](https://clojars.org/org.clojars.chinmay_dd/r2pipe)
+
+## Usage
+
+```clojure
+;; Start up the REPL and include r2 pipe lib
+user=> (require '[r2pipe.core :refer :all])
+
+;; Configure the r2 path. It will default to "/usr/bin/r2".
+user=> (configure-path "/usr/bin/r2")
+
+;; Open the file into r2
+user=> (r2open "binary")
+#'r2pipe.core/pipe
+
+;; Execute a command in r2
+user=> (r2cmd "pi 5")
+"xor ebp, ebp\npop esi\nmov ecx, esp\nand esp, 0xfffffff0\npush eax\n"
+```
+
+### Todo
+
+A lot of things!

--- a/clojure/project.clj
+++ b/clojure/project.clj
@@ -1,0 +1,7 @@
+(defproject org.clojars.chinmay_dd/r2pipe "0.0.2"
+  :description "Communicate to Radare2 via pipes"
+  :dependencies [[org.clojure/clojure "1.8.0"]
+                 [me.raynes/conch "0.8.0"]]
+
+  :plugins      [[lein-codox "0.9.5"]]
+  )

--- a/clojure/src/r2pipe/core.clj
+++ b/clojure/src/r2pipe/core.clj
@@ -1,0 +1,42 @@
+(ns r2pipe.core
+    (:refer-clojure :exclude [read-string])
+    (:require [me.raynes.conch.low-level :as sh]
+              [clojure.java.io :as io]))
+
+;; Define the default path for r2 to load.
+(def r2path "/usr/bin/r2")
+
+(defn configure-path
+  "Confgiure the r2 path."
+  [path]
+  (def r2path path))
+
+(defn r2open
+  "Opens a file in r2 and starts a process instance"
+  [input_file]
+  (def pipe (sh/proc r2path "-q0" (str input_file))))
+
+(defn r2print
+  "Read from the r2 process(pipe) and print."
+  []
+  (dotimes [i (.available (get pipe :out))] (print (str (char (.read (get pipe :out)))))))
+
+(defn r2write
+  "Write to the r2 process"
+  [input]
+  (.write (get pipe :in) (.getBytes (str input "\n")))
+  (.flush (get pipe :in)))
+
+(defn r2string
+  "Returns a string representation of the output shown by radare2"
+  []
+  (apply str (repeatedly (.available (get pipe :out)) #(str (char (.read (get pipe :out)))))))
+
+(defn r2cmd
+  "Runs an r2 command and returns the result as a string"
+  [input]
+  (do
+      (r2write input)
+      ;; 1337 hax! This is to offset the latency created due to stream buffering.
+      (Thread/sleep 1)
+      (r2string)))

--- a/clojure/test/r2pipe/clj_test.clj
+++ b/clojure/test/r2pipe/clj_test.clj
@@ -1,0 +1,5 @@
+(ns r2pipe-test
+  (:require [clojure.test :refer :all]
+            [r2pipe.clj :refer :all]))
+
+;; WRITE TESTS!


### PR DESCRIPTION
The r2pipe.clj repository contains initial code for the Clojure pipe. Adding it to the main repository here.