### PR TITLE
Perl namespace change

### DIFF
--- a/perl/MANIFEST
+++ b/perl/MANIFEST
@@ -1,3 +1,3 @@
-lib/Pwn/r2pipe.pm
+lib/Radare/r2pipe.pm
 Makefile.PL
 t/test.pl

--- a/perl/Makefile.PL
+++ b/perl/Makefile.PL
@@ -3,9 +3,9 @@ use warnings;
 use ExtUtils::MakeMaker;
 
 WriteMakefile (
-	NAME		=>	'Pwn::r2pipe',
+	NAME		=>	'Radare::r2pipe',
 	AUTHOR		=> 	'adri',
-	VERSION_FROM	=>	'lib/Pwn/r2pipe.pm',
-	ABSTRACT_FROM	=>	'lib/Pwn/r2pipe.pm',
+	VERSION_FROM	=>	'lib/Radare/r2pipe.pm',
+	ABSTRACT_FROM	=>	'lib/Radare/r2pipe.pm',
 	PREREQ_PM	=>	{'JSON' => 0, 'IO::Pty::Easy' => 0, 'IO::Socket::INET' => 0, 'LWP::UserAgent' => 0, 'URI::Escape' => 0},
 );

--- a/perl/README.md
+++ b/perl/README.md
@@ -1,15 +1,15 @@
-# Pwn::r2pipe
+# Radare::r2pipe
 
-    use Pwn::r2pipe;
+    use Radre::r2pipe;
 
-    my $r2 = Pwn::r2pipe->new('/bin/ls');
+    my $r2 = Radare::r2pipe->new('/bin/ls');
     my $result = $r2->cmd('iI');
     my $ds = $r2->cmdj('ij');
     print "Architecture: " . $ds->{bin}->{machine} . "\n";
     $r2->quit();
 
     # Other stuff
-    $r2 = Pwn::r2pipe->new;
+    $r2 = Radare::r2pipe->new;
     $r2->open('http://localhost:9090');
     $r2->cmd('pi 5');
     $r2->close(); # Same as quit()

--- a/perl/lib/Radare/r2pipe.pm
+++ b/perl/lib/Radare/r2pipe.pm
@@ -1,5 +1,5 @@
 # Declare namespace
-package Pwn::r2pipe;
+package Radare::r2pipe;
 
 # Declare dependencies
 use strict;
@@ -210,7 +210,7 @@ __END__
 
 =head1 NAME
 
-Pwn::r2pipe - Interface with radare2
+Radare::r2pipe - Interface with radare2
 
 =head1 VERSION
 
@@ -218,15 +218,15 @@ version 0.1
 
 =head1 SYNOPSIS
 
-    use Pwn::r2pipe;
+    use Radare::r2pipe;
 
-    my $r2 = Pwn::r2pipe->new('/bin/ls');
+    my $r2 = Radare::r2pipe->new('/bin/ls');
     $r2->cmd('iI');
     $r2->cmdj('ij');
     $r2->quit();
 
     # Other stuff
-    $r2 = Pwn::r2pipe->new;
+    $r2 = Radare::r2pipe->new;
     $r2->open('/bin/ls');
     $r2->cmd('pi 5');
     $r2->close(); # Same as quit()

--- a/perl/t/test.pl
+++ b/perl/t/test.pl
@@ -1,7 +1,7 @@
-use Pwn::r2pipe;
+use Radare::r2pipe;
 
 print "General functionality test...\n";
-my $r2pipe = Pwn::r2pipe->new("/bin/ls");
+my $r2pipe = Radare::r2pipe->new("/bin/ls");
 print $r2pipe->cmd("pi 10");
 print $r2pipe->cmd("iI");
 my $ds = $r2pipe->cmdj("ij");
@@ -9,18 +9,18 @@ print "Architecture: " . $ds->{bin}->{machine} . "\n";
 $r2pipe->quit();
 
 print "\n\nTesting open()...\n";
-my $o = Pwn::r2pipe->new;
+my $o = Radare::r2pipe->new;
 $o->open("/bin/ls");
 print $o->cmd('iI');
 $o->quit();
 
 print "\n\nTesting TCP...\n";
-my $tcp = Pwn::r2pipe->new("tcp://127.0.0.1:9080");
+my $tcp = Radare::r2pipe->new("tcp://127.0.0.1:9080");
 print $tcp->cmd('pi 20') . "\n";
 $tcp->quit();
 
 print "\n\nTesting HTTP...\n";
-my $http = Pwn::r2pipe->new("http://127.0.0.1:9090");
+my $http = Radare::r2pipe->new("http://127.0.0.1:9090");
 my $output = $http->cmd('pi 30');
 print "Output: $output\n";
 $http->close();


### PR DESCRIPTION
Changed from Pwn::r2pipe to Radare::r2pipe. 

Fixes #8 