### PR TITLE
[python] use PIPE as stderr

### DIFF
--- a/python/r2pipe/__init__.py
+++ b/python/r2pipe/__init__.py
@@ -146,7 +146,7 @@ class open:
 			cmd = ["radare2", "-q0", filename]
 			cmd = cmd[:1] + flags + cmd[1:]
 			try:
-				self.process = Popen(cmd, shell=False, stdin=PIPE, stdout=PIPE)
+				self.process = Popen(cmd, shell=False, stdin=PIPE, stdout=PIPE, stderr=PIPE)
 			except:
 				raise Exception("ERROR: Cannot find radare2 in PATH")
 			self.process.stdout.read(1) # Reads initial \x00

--- a/python/r2pipe/__init__.py
+++ b/python/r2pipe/__init__.py
@@ -81,7 +81,7 @@ def in_rlang():
 class open:
 	"""Class representing an r2pipe connection with a running radare2 instance
 	"""
-	def __init__(self, filename='', flags=[]):
+	def __init__(self, filename='', flags=[], verbose=True):
 		"""Open a new r2 pipe
 		The 'filename' can be one of the following:
 
@@ -145,8 +145,9 @@ class open:
 			self._cmd = self._cmd_process
 			cmd = ["radare2", "-q0", filename]
 			cmd = cmd[:1] + flags + cmd[1:]
+			fd = sys.stderr.fileno() if verbose else PIPE
 			try:
-				self.process = Popen(cmd, shell=False, stdin=PIPE, stdout=PIPE, stderr=PIPE)
+				self.process = Popen(cmd, shell=False, stdin=PIPE, stdout=PIPE, stderr=fd)
 			except:
 				raise Exception("ERROR: Cannot find radare2 in PATH")
 			self.process.stdout.read(1) # Reads initial \x00


### PR DESCRIPTION
this patch allows a user to close r2's stderr like this:
```
r2 = r2pipe.open("/bin/ls")
r2.process.stderr.close()
```
this can be usefull as r2 outputs some "noise" which may not be usefull with r2pipe.