### PR TITLE
improved error message for non-json commands in cmdj and equivalents

### DIFF
--- a/python-async/r2pipe/open_base.py
+++ b/python-async/r2pipe/open_base.py
@@ -211,7 +211,7 @@ class OpenBase(object):
 		try:
 			data = json.loads(self.cmd(cmd))
 		except (ValueError, KeyError, TypeError) as e:
-			sys.stderr.write("r2pipe.cmdj.Error: %s\n" % e)
+			sys.stderr.write("r2pipe.cmdj.Error: %s (are you using a command that outputs JSON?)\n" % e)
 			data = None
 		return data
 
@@ -236,6 +236,6 @@ class OpenBase(object):
 		try:
 			data = json.loads(self.syscmd(cmd))
 		except (ValueError, KeyError, TypeError) as e:
-			sys.stderr.write("r2pipe.syscmdj.Error %s\n" % (e))
+			sys.stderr.write("r2pipe.syscmdj.Error: %s (are you using a command that outputs JSON?)\n" % (e))
 			data = None
 		return data

--- a/python/r2pipe/__init__.py
+++ b/python/r2pipe/__init__.py
@@ -251,7 +251,7 @@ class open:
 		try:
 			data = json.loads(self.cmd(cmd))
 		except (ValueError, KeyError, TypeError) as e:
-			sys.stderr.write ("r2pipe.cmdj.Error: %s\n"%(e))
+			sys.stderr.write ("r2pipe.cmdj.Error: %s (are you using a command that outputs JSON?)\n"%(e))
 			data = None
 		return data
 
@@ -276,7 +276,7 @@ class open:
 		try:
 			data = json.loads(self.syscmd(cmd))
 		except (ValueError, KeyError, TypeError) as e:
-			sys.stderr.write ("r2pipe.syscmdj.Error %s\n"%(e))
+			sys.stderr.write ("r2pipe.syscmdj.Error: %s (are you using a command that outputs JSON?)\n"%(e))
 			data = None
 		return data
 


### PR DESCRIPTION
as discussed in #radare

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/radare/radare2-r2pipe/19)
<!-- Reviewable:end -->
