### PR TITLE
use explicit relative import

### DIFF
--- a/python/r2pipe/__init__.py
+++ b/python/r2pipe/__init__.py
@@ -38,7 +38,7 @@ except:
 	r2lang = None
 
 try:
-	import native
+	from .native import RCore
 	has_native = True
 except:
 	has_native = False
@@ -203,7 +203,7 @@ class open:
 		if not has_native:
 			raise Exception('No native ctypes connector available')
 		if not hasattr(self, 'native'):
-			self.native = native.RCore()
+			self.native = RCore()
 			self.native.cmd_str("o "+self.uri)
 		return self.native.cmd_str(cmd)
 

--- a/python/r2pipe/native.py
+++ b/python/r2pipe/native.py
@@ -33,6 +33,12 @@ class WrappedRMethod(object):
 				self.method.argtypes = [eval(x.strip()) for x in self.args.split(',')]
 			self.method.restype = eval(self.ret) if self.ret else None
 			self.args_set = True
+		a = list(a)
+		for i, argt in enumerate(self.method.argtypes):
+			if argt is c_char_p:
+				a[i] = a[i].encode()
+		if self.method.restype is c_char_p:
+			return self.method(*a).decode()
 		return self.method(*a)
 
 class WrappedApiMethod(object):
@@ -45,7 +51,10 @@ class WrappedApiMethod(object):
 	def __call__(self, *a):
 		result = self.method(self._o, *a)
 		if self.ret2:
-			result = eval(self.ret2)(result)
+			if self.ret2 == 'c_char_p':
+				return result
+			else:
+				result = eval(self.ret2)(result)
 		if self.last:
 			return getattr(result, self.last)
 		return result
@@ -84,9 +93,9 @@ class RCore(Structure): #1
 	cmd_str, r_core_cmd_str = register('r_core_cmd_str','c_void_p, c_char_p','c_char_p')
 	free, r_core_free = register('r_core_free','c_void_p', 'c_void_p')
 
-#c = RCore()
-#c.cmd_str("o /bin/ls")
-#print c
-#print c.cmd_str("s entry0;pd 20");
-#c.free();
+#  c = RCore()
+#  c.cmd_str("o /bin/ls")
+#  print(c)
+#  print(c.cmd_str("s entry0;pd 20"))
+#  c.free();
 


### PR DESCRIPTION
fixes #20 
However I find that using RCore from native directly has one more problem. The `cmd_str` method requires bytes not string in py3 for `c_char_p` arg. Would you like another PR to handle them? (decode and encode for `c_char_p` argtypes and restype)

edit: provided anyway...