### PR TITLE
r2pipe-promise: omit undefined parameters

### DIFF
--- a/nodejs/r2pipe-promise/index.js
+++ b/nodejs/r2pipe-promise/index.js
@@ -5,13 +5,17 @@ const r2pipe = require('r2pipe');
 module.exports = {
   open: function openPromise (file, options) {
     return new Promise(function (resolve, reject) {
-      r2pipe.open(file, options, (err, res) => {
+      r2pipe.open(...[file, options, (err, res) => {
         if (err) {
           return reject(err);
         }
         resolve(r2promise(res));
-      });
+      }].filter(argDefined));
     });
+
+    function argDefined (x) {
+      return x !== undefined;
+    }
   }
 };
 


### PR DESCRIPTION
In this way the parameter matching should be compatible with what `r2pipe.open` does internally. This permits the user to call `open()` without parameters to attach to current r2 session.