### PR TITLE
Clear pending rejects at the end

### DIFF
--- a/nodejs/r2pipe-promise/index.js
+++ b/nodejs/r2pipe-promise/index.js
@@ -10,7 +10,9 @@ module.exports = {
       let cbResolved = false;
       function cb (err, r2) {
         if (cbResolved && err) {
-          for (const pendingReject of pendingRejects) {
+          const toReject = new Set(pendingRejects);
+          pendingRejects.clear();
+          for (const pendingReject of toReject) {
             pendingReject(err);
           }
           return;


### PR DESCRIPTION
Mostly cosmetic since r2 is crashed at that point, but just in case.