### PR TITLE
python: fix for endless loop

### DIFF
--- a/python/r2pipe/__init__.py
+++ b/python/r2pipe/__init__.py
@@ -272,7 +272,7 @@ class open:
                         Returns a Python object respresenting the parsed JSON
                 """
                 try:
-                        data = json.loads(self.cmd(cmd))
+                        data = json.loads(self.cmd(cmd).replace('\n', ''))
                 except (ValueError, KeyError, TypeError) as e:
                         sys.stderr.write("r2pipe.cmdj.Error: %s\n" % (e))
                         data = None

--- a/python/r2pipe/__init__.py
+++ b/python/r2pipe/__init__.py
@@ -1,4 +1,4 @@
-#/usr/bin/env python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 """r2pipe
@@ -34,300 +34,303 @@ import socket
 import urllib
 from subprocess import Popen, PIPE
 try:
-	import r2lang
+        import r2lang
 except:
-	r2lang = None
+        r2lang = None
 
 try:
-	from .native import RCore
-	has_native = True
+        from .native import RCore
+        has_native = True
 except:
-	has_native = False
+        has_native = False
 
-VERSION="0.9.2"
+VERSION = "0.9.2"
 
-if sys.version_info >= (3,0):
-	import urllib.request
-	urlopen = urllib.request.urlopen
-	import urllib.error
-	URLError = urllib.error.URLError
+if sys.version_info >= (3, 0):
+        import urllib.request
+        urlopen = urllib.request.urlopen
+        import urllib.error
+        URLError = urllib.error.URLError
 else:
-	import urllib2
-	urlopen = urllib2.urlopen
-	URLError = urllib2.URLError
-if os.name=="nt":
-	from ctypes import *
-	import msvcrt
-	GENERIC_READ = 0x80000000
-	GENERIC_WRITE = 0x40000000
-	OPEN_EXISTING = 0x3
-	INVALID_HANDLE_VALUE = -1
-	PIPE_READMODE_MESSAGE = 0x2
-	ERROR_PIPE_BUSY = 231
-	ERROR_MORE_DATA = 234
-	BUFSIZE = 4096
-	szPipename = "\\\\.\\pipe\\"
-	chBuf = create_string_buffer(BUFSIZE)
-	cbRead = c_ulong(0)
-	cbWritten = c_ulong(0)
+        import urllib2
+        urlopen = urllib2.urlopen
+        URLError = urllib2.URLError
+if os.name == "nt":
+        from ctypes import byref, c_ulong, create_string_buffer, windll
+        GENERIC_READ = 0x80000000
+        GENERIC_WRITE = 0x40000000
+        OPEN_EXISTING = 0x3
+        INVALID_HANDLE_VALUE = -1
+        PIPE_READMODE_MESSAGE = 0x2
+        ERROR_PIPE_BUSY = 231
+        ERROR_MORE_DATA = 234
+        BUFSIZE = 4096
+        szPipename = "\\\\.\\pipe\\"
+        chBuf = create_string_buffer(BUFSIZE)
+        cbRead = c_ulong(0)
+        cbWritten = c_ulong(0)
+
 
 def version():
-	"""Return string with the version of the r2pipe library
-	"""
-	return VERSION
+        """Return string with the version of the r2pipe library
+        """
+        return VERSION
+
 
 def in_rlang():
-	return r2lang is not None and r2lang.cmd is not None
+        return r2lang is not None and r2lang.cmd is not None
+
 
 class open:
-	"""Class representing an r2pipe connection with a running radare2 instance
-	"""
-	def __init__(self, filename='', flags=[]):
-		"""Open a new r2 pipe
-		The 'filename' can be one of the following:
+        """Class representing an r2pipe connection with a running radare2 instance
+        """
+        def __init__(self, filename='', flags=[]):
+                """Open a new r2 pipe
+                The 'filename' can be one of the following:
 
-		* absolute or relative path to file
-		* http://<host>:<port>/cmd to connect to an r2 webserver
-		* tcp://<host>:<port> to connect to an r2 tcp server
-		* #!pipe when launching it from r2 via RLang.pipe
+                * absolute or relative path to file
+                * http://<host>:<port>/cmd to connect to an r2 webserver
+                * tcp://<host>:<port> to connect to an r2 tcp server
+                * #!pipe when launching it from r2 via RLang.pipe
 
-		Args:
-			filename (str): path to filename or uri
-			flags (list of str): arguments, either in comapct form
-				("-wdn") or sepparated by commas ("-w","-d","-n")
-		Returns:
-			Returns an object with methods to interact with r2 via commands
-		"""
-		if not filename and in_rlang():
-			self._cmd = self._cmd_rlang
-			return
-		try:
-			if os.name=="nt":
-				mypipename=os.environ['r2pipe_path']
-				while 1:
-					hPipe = windll.kernel32.CreateFileA(szPipename+mypipename, GENERIC_READ |GENERIC_WRITE, 0, None, OPEN_EXISTING, 0, None)
-					if (hPipe != INVALID_HANDLE_VALUE):
-						break
-					else:
-						print ("Invalid Handle Value")
-					if (windll.kernel32.GetLastError() != ERROR_PIPE_BUSY):
-						print ("Could not open pipe")
-						return
-					elif ((windll.kernel32.WaitNamedPipeA(szPipename, 20000)) ==0):
-						print ("Could not open pipe\n")
-						return
-				windll.kernel32.WriteFile(hPipe, "e scr.color=false\n",18, byref(cbWritten), None)
-				windll.kernel32.ReadFile(hPipe, chBuf, BUFSIZE, byref(cbRead), None)
-				self.pipe = [hPipe, hPipe]
-				self._cmd = self._cmd_pipe
-			else:
-				self.pipe = [ int(os.environ['R2PIPE_IN']), int(os.environ['R2PIPE_OUT']) ]
-				self._cmd = self._cmd_pipe
-			self.url = "#!pipe"
-			return
-		except:
-			pass
-		if filename.startswith("#!pipe"):
-			raise Exception("ERROR: Cannot use #!pipe without R2PIPE_{IN|OUT} env")
-		if filename.startswith("http"):
-			self._cmd = self._cmd_http
-			self.uri = filename + "/cmd"
-		elif filename.startswith("ccall://"):
-			self._cmd = self._cmd_native
-			self.uri = filename[7:]
-		elif filename.startswith("tcp"):
-			r = re.match(r'tcp://(\d+\.\d+.\d+.\d+):(\d+)/?', filename)
-			if not r:
-				raise Exception("String doesn't match tcp format")
-			self._cmd = self._cmd_tcp
-			self.conn = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-			self.conn.connect((r.group(1), int(r.group(2))))
-		else:
-			self._cmd = self._cmd_process
-			cmd = ["radare2", "-q0", filename]
-			cmd = cmd[:1] + flags + cmd[1:]
-			try:
-				self.process = Popen(cmd, shell=False, stdin=PIPE, stdout=PIPE)
-			except:
-				raise Exception("ERROR: Cannot find radare2 in PATH")
-			self.process.stdout.read(1) # Reads initial \x00
-			# make it non-blocking to speedup reading
-			self.nonblocking = True
-			if self.nonblocking:
-				fd = self.process.stdout.fileno()
-				fl = fcntl.fcntl(fd, fcntl.F_GETFL)
-				fcntl.fcntl(fd, fcntl.F_SETFL, fl | os.O_NONBLOCK)
+                Args:
+                        filename (str): path to filename or uri
+                        flags (list of str): arguments, either in comapct form
+                                ("-wdn") or sepparated by commas ("-w","-d","-n")
+                Returns:
+                        Returns an object with methods to interact with r2 via commands
+                """
+                if not filename and in_rlang():
+                        self._cmd = self._cmd_rlang
+                        return
+                try:
+                        if os.name == "nt":
+                                mypipename = os.environ['r2pipe_path']
+                                while 1:
+                                        hPipe = windll.kernel32.CreateFileA(szPipename + mypipename, GENERIC_READ | GENERIC_WRITE, 0, None, OPEN_EXISTING, 0, None)
+                                        if (hPipe != INVALID_HANDLE_VALUE):
+                                                break
+                                        else:
+                                                print("Invalid Handle Value")
+                                        if (windll.kernel32.GetLastError() != ERROR_PIPE_BUSY):
+                                                print("Could not open pipe")
+                                                return
+                                        elif ((windll.kernel32.WaitNamedPipeA(szPipename, 20000)) == 0):
+                                                print("Could not open pipe\n")
+                                                return
+                                windll.kernel32.WriteFile(hPipe, "e scr.color=false\n", 18, byref(cbWritten), None)
+                                windll.kernel32.ReadFile(hPipe, chBuf, BUFSIZE, byref(cbRead), None)
+                                self.pipe = [hPipe, hPipe]
+                                self._cmd = self._cmd_pipe
+                        else:
+                                self.pipe = [int(os.environ['R2PIPE_IN']), int(os.environ['R2PIPE_OUT'])]
+                                self._cmd = self._cmd_pipe
+                        self.url = "#!pipe"
+                        return
+                except:
+                        pass
+                if filename.startswith("#!pipe"):
+                        raise Exception("ERROR: Cannot use #!pipe without R2PIPE_{IN|OUT} env")
+                if filename.startswith("http"):
+                        self._cmd = self._cmd_http
+                        self.uri = filename + "/cmd"
+                elif filename.startswith("ccall://"):
+                        self._cmd = self._cmd_native
+                        self.uri = filename[7:]
+                elif filename.startswith("tcp"):
+                        r = re.match(r'tcp://(\d+\.\d+.\d+.\d+):(\d+)/?', filename)
+                        if not r:
+                                raise Exception("String doesn't match tcp format")
+                        self._cmd = self._cmd_tcp
+                        self.conn = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                        self.conn.connect((r.group(1), int(r.group(2))))
+                else:
+                        self._cmd = self._cmd_process
+                        cmd = ["radare2", "-q0", filename]
+                        cmd = cmd[:1] + flags + cmd[1:]
+                        try:
+                                self.process = Popen(cmd, shell=False, stdin=PIPE, stdout=PIPE)
+                        except:
+                                raise Exception("ERROR: Cannot find radare2 in PATH")
+                        self.process.stdout.read(1)  # Reads initial \x00
+                        # make it non-blocking to speedup reading
+                        self.nonblocking = True
+                        if self.nonblocking:
+                                fd = self.process.stdout.fileno()
+                                fl = fcntl.fcntl(fd, fcntl.F_GETFL)
+                                fcntl.fcntl(fd, fcntl.F_SETFL, fl | os.O_NONBLOCK)
 
-	def _cmd_process(self, cmd):
-		cmd = cmd.strip().replace("\n", ";")
-		if sys.version_info >= (3,0):
-			self.process.stdin.write(bytes(cmd+'\n','utf-8'))
-		else:
-			self.process.stdin.write(cmd+'\n')
-		self.process.stdin.flush()
-		out = b''
-		while True:
-			if self.nonblocking:
-				try:
-					foo = self.process.stdout.read(4096)
-				except:
-					continue
-			else:
-				foo = self.process.stdout.read(1)
-			if foo[-1] == b'\x00':
-				out += foo[0:-1]
-				break
-			out += foo
-		return out #.decode('utf-8')
+        def _cmd_process(self, cmd):
+                cmd = cmd.strip().replace("\n", ";")
+                if sys.version_info >= (3, 0):
+                        self.process.stdin.write(bytes(cmd + '\n', 'utf-8'))
+                else:
+                        self.process.stdin.write(cmd + '\n')
+                self.process.stdin.flush()
+                out = b''
+                while True:
+                        if self.nonblocking:
+                                try:
+                                        foo = self.process.stdout.read(4096)
+                                except:
+                                        continue
+                        else:
+                                foo = self.process.stdout.read(1)
+                        if foo[-1] == b'\x00':
+                                out += foo[0:-1]
+                                break
+                        out += foo
+                return out  # .decode('utf-8')
 
-	def _cmd_tcp(self, cmd):
-		res = b''
-		self.conn.sendall(str.encode(cmd, 'utf-8'))
-		data = self.conn.recv(512)
-		while data:
-			res += data
-			data = self.conn.recv(512)
-		return res.decode('utf-8')
+        def _cmd_tcp(self, cmd):
+                res = b''
+                self.conn.sendall(str.encode(cmd, 'utf-8'))
+                data = self.conn.recv(512)
+                while data:
+                        res += data
+                        data = self.conn.recv(512)
+                return res.decode('utf-8')
 
-	def _cmd_pipe(self, cmd):
-		out = ''
-		cmd = cmd.strip().replace("\n", ";")
-		if os.name=="nt":
-			fSuccess = windll.kernel32.WriteFile(self.pipe[1],cmd,len(cmd), byref(cbWritten), None)
-			while True:
-				fSuccess = windll.kernel32.ReadFile(self.pipe[1], chBuf, BUFSIZE,byref(cbRead), None)
-				out += chBuf.value
-				if ord(chBuf[cbRead.value-1]) == 0:
-					out = out[0:-1]
-					break
-		else:
-			os.write (self.pipe[1], cmd)
-			while True:
-				res = os.read (self.pipe[0], 4096)
-				if res[-1] == b'\x00':
-					res = res[0:-1]
-				if (len(res) < 1):
-					break
-				out += res
-				if (len(res) < 4096):
-					break
-		return out.decode('utf-8')
+        def _cmd_pipe(self, cmd):
+                out = ''
+                cmd = cmd.strip().replace("\n", ";")
+                if os.name == "nt":
+                        windll.kernel32.WriteFile(self.pipe[1], cmd, len(cmd), byref(cbWritten), None)
+                        while True:
+                                windll.kernel32.ReadFile(self.pipe[1], chBuf, BUFSIZE, byref(cbRead), None)
+                                out += chBuf.value
+                                if ord(chBuf[cbRead.value - 1]) == 0:
+                                        out = out[0:-1]
+                                        break
+                else:
+                        os.write(self.pipe[1], cmd)
+                        while True:
+                                res = os.read(self.pipe[0], 4096)
+                                if res[-1] == b'\x00':
+                                        res = res[0:-1]
+                                if (len(res) < 1):
+                                        break
+                                out += res
+                                if (len(res) < 4096):
+                                        break
+                return out.decode('utf-8')
 
-	def _cmd_native(self, cmd):
-		cmd = cmd.strip().replace("\n", ";")
-		if not has_native:
-			raise Exception('No native ctypes connector available')
-		if not hasattr(self, 'native'):
-			self.native = RCore()
-			self.native.cmd_str("o "+self.uri)
-		return self.native.cmd_str(cmd)
+        def _cmd_native(self, cmd):
+                cmd = cmd.strip().replace("\n", ";")
+                if not has_native:
+                        raise Exception('No native ctypes connector available')
+                if not hasattr(self, 'native'):
+                        self.native = RCore()
+                        self.native.cmd_str("o " + self.uri)
+                return self.native.cmd_str(cmd)
 
-	def _cmd_rlang(self, cmd):
-		return r2lang.cmd(cmd)
+        def _cmd_rlang(self, cmd):
+                return r2lang.cmd(cmd)
 
-	def _cmd_http(self, cmd):
-		try:
-			try:
-				quocmd = urllib.parse.quote(cmd)
-			except:
-				quocmd = urllib.quote(cmd)
-			response = urlopen('{uri}/{cmd}'.format(uri=self.uri, cmd=quocmd))
-			return response.read().decode('utf-8')
-		except URLError:
-			pass
-		return None
+        def _cmd_http(self, cmd):
+                try:
+                        try:
+                                quocmd = urllib.parse.quote(cmd)
+                        except:
+                                quocmd = urllib.quote(cmd)
+                        response = urlopen('{uri}/{cmd}'.format(uri=self.uri, cmd=quocmd))
+                        return response.read().decode('utf-8')
+                except URLError:
+                        pass
+                return None
 
-	def quit(self):
-		"""Quit current r2pipe session and kill
-		"""
-		self.cmd("q")
-		if hasattr(self, 'process'):
-			self.process.stdin.flush()
-			self.process.terminate()
-			self.process.wait()
+        def quit(self):
+                """Quit current r2pipe session and kill
+                """
+                self.cmd("q")
+                if hasattr(self, 'process'):
+                        self.process.stdin.flush()
+                        self.process.terminate()
+                        self.process.wait()
 
-	# r2 commands
-	def cmd(self, cmd):
-		"""Run an r2 command return string with result
-		Args:
-			cmd (str): r2 command
-		Returns:
-			Returns an string with the results of the command
-		"""
-		res = self._cmd(cmd)
-		if res is not None:
-			return res.strip()
-		return None
+        # r2 commands
+        def cmd(self, cmd):
+                """Run an r2 command return string with result
+                Args:
+                        cmd (str): r2 command
+                Returns:
+                        Returns an string with the results of the command
+                """
+                res = self._cmd(cmd)
+                if res is not None:
+                        return res.strip()
+                return None
 
-	def cmdj(self, cmd):
-		"""Same as cmd() but evaluates JSONs and returns an object
-		Args:
-			cmd (str): r2 command
-		Returns:
-			Returns a Python object respresenting the parsed JSON
-		"""
-		try:
-			data = json.loads(self.cmd(cmd))
-		except (ValueError, KeyError, TypeError) as e:
-			sys.stderr.write ("r2pipe.cmdj.Error: %s\n"%(e))
-			data = None
-		return data
+        def cmdj(self, cmd):
+                """Same as cmd() but evaluates JSONs and returns an object
+                Args:
+                        cmd (str): r2 command
+                Returns:
+                        Returns a Python object respresenting the parsed JSON
+                """
+                try:
+                        data = json.loads(self.cmd(cmd))
+                except (ValueError, KeyError, TypeError) as e:
+                        sys.stderr.write("r2pipe.cmdj.Error: %s\n" % (e))
+                        data = None
+                return data
 
-	def syscmd(self, cmd):
-		"""Executes a program and returns the output (stdout only)
-		Args:
-			cmd (str): commandline shell command
-		Returns:
-			Returns a string with the output
-		"""
-		p = Popen(cmd, shell=True, stdin=PIPE, stdout=PIPE)
-		out, err = p.communicate()
-		return out
+        def syscmd(self, cmd):
+                """Executes a program and returns the output (stdout only)
+                Args:
+                        cmd (str): commandline shell command
+                Returns:
+                        Returns a string with the output
+                """
+                p = Popen(cmd, shell=True, stdin=PIPE, stdout=PIPE)
+                out, err = p.communicate()
+                return out
 
-	def syscmdj(self, cmd):
-		"""Executes a program and returns an object representing the parsed JSON of the output
-		Args:
-			cmd (str): commandline shell command
-		Returns:
-			Returns an object constructed by parsing the JSON returned by the command
-		"""
-		try:
-			data = json.loads(self.syscmd(cmd))
-		except (ValueError, KeyError, TypeError) as e:
-			sys.stderr.write ("r2pipe.syscmdj.Error %s\n"%(e))
-			data = None
-		return data
+        def syscmdj(self, cmd):
+                """Executes a program and returns an object representing the parsed JSON of the output
+                Args:
+                        cmd (str): commandline shell command
+                Returns:
+                        Returns an object constructed by parsing the JSON returned by the command
+                """
+                try:
+                        data = json.loads(self.syscmd(cmd))
+                except (ValueError, KeyError, TypeError) as e:
+                        sys.stderr.write("r2pipe.syscmdj.Error %s\n" % (e))
+                        data = None
+                return data
+
 
 # Hello World
 if __name__ == "__main__":
-	print("[+] Spawning r2 tcp and http servers")
-	os.system("pkill r2")
-	os.system("r2 -qc.:9080 /bin/ls &")
-	os.system("r2 -qc=h /bin/ls &")
-	time.sleep(1)
-	# Test r2pipe with local process
-	print("[+] Testing python r2pipe local")
-	rlocal = open("/bin/ls")
-	print(rlocal.cmd("pi 5"))
-	#print rlocal.cmd("pn")
-	info = rlocal.cmdj("ij")
-	print ("Architecture: " + info['bin']['machine'])
+        print("[+] Spawning r2 tcp and http servers")
+        os.system("pkill r2")
+        os.system("r2 -qc.:9080 /bin/ls &")
+        os.system("r2 -qc=h /bin/ls &")
+        time.sleep(1)
+        # Test r2pipe with local process
+        print("[+] Testing python r2pipe local")
+        rlocal = open("/bin/ls")
+        print(rlocal.cmd("pi 5"))
+        # print rlocal.cmd("pn")
+        info = rlocal.cmdj("ij")
+        print("Architecture: " + info['bin']['machine'])
 
-	# Test r2pipe with remote tcp process (launch it with "r2 -qc.:9080 myfile")
-	print("[+] Testing python r2pipe tcp://")
-	rremote = open("tcp://127.0.0.1:9080")
-	disas = rremote.cmd("pi 5")
-	if not disas:
-		print("Error with remote tcp conection")
-	else:
-		print(disas)
+        # Test r2pipe with remote tcp process (launch it with "r2 -qc.:9080 myfile")
+        print("[+] Testing python r2pipe tcp://")
+        rremote = open("tcp://127.0.0.1:9080")
+        disas = rremote.cmd("pi 5")
+        if not disas:
+                print("Error with remote tcp conection")
+        else:
+                print(disas)
 
-	# Test r2pipe with remote http process (launch it with "r2 -qc=H myfile")
-	print("[+] Testing python r2pipe http://")
-	rremote = open("http://127.0.0.1:9090")
-	disas = rremote.cmd("pi 5")
-	if not disas:
-		print("Error with remote http conection")
-	else:
-		print(disas)
-	os.system("pkill -INT r2")
+        # Test r2pipe with remote http process (launch it with "r2 -qc=H myfile")
+        print("[+] Testing python r2pipe http://")
+        rremote = open("http://127.0.0.1:9090")
+        disas = rremote.cmd("pi 5")
+        if not disas:
+                print("Error with remote http conection")
+        else:
+                print(disas)
+        os.system("pkill -INT r2")

--- a/python/r2pipe/__init__.py
+++ b/python/r2pipe/__init__.py
@@ -32,6 +32,7 @@ import json
 import fcntl
 import socket
 import urllib
+from io import TextIOWrapper
 from subprocess import Popen, PIPE
 try:
         import r2lang
@@ -167,20 +168,22 @@ class open:
                 else:
                         self.process.stdin.write(cmd + '\n')
                 self.process.stdin.flush()
-                out = b''
+                # XXX: Use the TextIOWrapper or we can get stuck in an endless loop!
+                r = TextIOWrapper(self.process.stdout, encoding='utf8')
+                out = ''
                 while True:
                         if self.nonblocking:
                                 try:
-                                        foo = self.process.stdout.read(4096)
+                                        foo = r.read(4096)
                                 except:
                                         continue
                         else:
-                                foo = self.process.stdout.read(1)
-                        if foo[-1] == b'\x00':
+                                foo = r.read(1)
+                        if len(foo) > 0 and foo[-1] == '\x00':
                                 out += foo[0:-1]
                                 break
                         out += foo
-                return out  # .decode('utf-8')
+                return out
 
         def _cmd_tcp(self, cmd):
                 res = b''

--- a/python/r2pipe/native.py
+++ b/python/r2pipe/native.py
@@ -1,101 +1,104 @@
-#/usr/bin/env python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 import sys
-from ctypes import *
+from ctypes import CDLL, Structure, WinDLL, addressof, c_char_p, c_void_p
 from ctypes.util import find_library
 
 if sys.platform.startswith('win'):
-	lib = WinDLL (find_library ('r_core'))
+        lib = WinDLL(find_library('r_core'))
 else:
-	lib = CDLL (find_library ('r_core'))
+        lib = CDLL(find_library('r_core'))
+
 
 class AddressHolder(object):
-	def __get__(self, obj, type_):
-		if getattr(obj, '_address', None) is None:
-			obj._address = addressof(obj)
-		return obj._address
+        def __get__(self, obj, type_):
+                if getattr(obj, '_address', None) is None:
+                        obj._address = addressof(obj)
+                return obj._address
 
-	def __set__(self, obj, value):
-		obj._address = value
+        def __set__(self, obj, value):
+                obj._address = value
+
 
 class WrappedRMethod(object):
-	def __init__(self, cname, args, ret):
-		self.cname = cname
-		self.args = args
-		self.ret = ret
-		self.args_set = False
-		self.method = getattr(lib, cname)
+        def __init__(self, cname, args, ret):
+                self.cname = cname
+                self.args = args
+                self.ret = ret
+                self.args_set = False
+                self.method = getattr(lib, cname)
 
-	def __call__(self, *a):
-		if not self.args_set:
-			if self.args:
-				self.method.argtypes = [eval(x.strip()) for x in self.args.split(',')]
-			self.method.restype = eval(self.ret) if self.ret else None
-			self.args_set = True
-		a = list(a)
-		for i, argt in enumerate(self.method.argtypes):
-			if argt is c_char_p:
-				a[i] = a[i].encode()
-		if self.method.restype is c_char_p:
-			return self.method(*a).decode()
-		return self.method(*a)
+        def __call__(self, *a):
+                if not self.args_set:
+                        if self.args:
+                                self.method.argtypes = [eval(x.strip()) for x in self.args.split(',')]
+                        self.method.restype = eval(self.ret) if self.ret else None
+                        self.args_set = True
+                a = list(a)
+                for i, argt in enumerate(self.method.argtypes):
+                        if argt is c_char_p:
+                                a[i] = a[i].encode()
+                if self.method.restype is c_char_p:
+                        return self.method(*a).decode()
+                return self.method(*a)
+
 
 class WrappedApiMethod(object):
-	def __init__(self, method, ret2, last):
-		self.method = method
-		self._o = None
-		self.ret2 = ret2
-		self.last = last
+        def __init__(self, method, ret2, last):
+                self.method = method
+                self._o = None
+                self.ret2 = ret2
+                self.last = last
 
-	def __call__(self, *a):
-		result = self.method(self._o, *a)
-		if self.ret2:
-			if self.ret2 == 'c_char_p':
-				return result
-			else:
-				result = eval(self.ret2)(result)
-		if self.last:
-			return getattr(result, self.last)
-		return result
+        def __call__(self, *a):
+                result = self.method(self._o, *a)
+                if self.ret2:
+                        if self.ret2 == 'c_char_p':
+                                return result
+                        else:
+                                result = eval(self.ret2)(result)
+                if self.last:
+                        return getattr(result, self.last)
+                return result
 
-	def __get__(self, obj, type_):
-		self._o = obj._o
-		return self
+        def __get__(self, obj, type_):
+                self._o = obj._o
+                return self
+
 
 def register(cname, args, ret):
-	ret2 = last = None
-	if ret:
-		if ret[0]>='A' and ret[0]<='Z':
-			x = ret.find('<')
-			if x != -1:
-				ret = ret[0:x]
-			last = 'contents'
-			ret = 'POINTER('+ret+')'
-		else:
-			last = 'value'
-			ret2 = ret
-			
-	method = WrappedRMethod(cname, args, ret)
-	wrapped_method = WrappedApiMethod(method, ret2, last)
-	return wrapped_method, method
+        ret2 = last = None
+        if ret:
+                if ret[0] >= 'A' and ret[0] <= 'Z':
+                        x = ret.find('<')
+                        if x != -1:
+                                ret = ret[0:x]
+                        last = 'contents'
+                        ret = 'POINTER(' + ret + ')'
+                else:
+                        last = 'value'
+                        ret2 = ret
+
+        method = WrappedRMethod(cname, args, ret)
+        wrapped_method = WrappedApiMethod(method, ret2, last)
+        return wrapped_method, method
 
 
-class RCore(Structure): #1
-	def __init__(self):
-		Structure.__init__(self)
-		r_core_new = lib.r_core_new
-		r_core_new.restype = c_void_p
-		self._o = r_core_new ()
+class RCore(Structure):  # 1
+        def __init__(self):
+                Structure.__init__(self)
+                r_core_new = lib.r_core_new
+                r_core_new.restype = c_void_p
+                self._o = r_core_new()
 
-	_o = AddressHolder()
+        _o = AddressHolder()
 
-	cmd_str, r_core_cmd_str = register('r_core_cmd_str','c_void_p, c_char_p','c_char_p')
-	free, r_core_free = register('r_core_free','c_void_p', 'c_void_p')
+        cmd_str, r_core_cmd_str = register('r_core_cmd_str', 'c_void_p, c_char_p', 'c_char_p')
+        free, r_core_free = register('r_core_free', 'c_void_p', 'c_void_p')
 
 #  c = RCore()
 #  c.cmd_str("o /bin/ls")
 #  print(c)
 #  print(c.cmd_str("s entry0;pd 20"))
 #  c.free();
-


### PR DESCRIPTION
I was experiencing an odd endless loop bug in _cmd_process when using python 3. Seemed to only occur when this line was present `out += foo` no idea why but using TextIOWrapper to decode on read has fixed this issue for me.

Also applied all the PEP8 warnings that vim was shouting at me!