### PR TITLE
python: allow non-printable characters in json

### DIFF
--- a/python/r2pipe/__init__.py
+++ b/python/r2pipe/__init__.py
@@ -279,7 +279,7 @@ class open:
                         Returns a Python object respresenting the parsed JSON
                 """
                 try:
-                        data = json.loads(self.cmd(cmd).replace('\n', ''))
+                        data = json.loads(self.cmd(cmd).replace('\n', ''), strict=False)
                 except (ValueError, KeyError, TypeError) as e:
                         sys.stderr.write("r2pipe.cmdj.Error: %s\n" % (e))
                         data = None


### PR DESCRIPTION
Let script.py be :
```
#!/usr/bin/python
# -*- coding: utf-8 -*-
# -*- mode: Python -*-

import r2pipe

r2 = r2pipe.open('/bin/ls')
r2.cmd('pf.S s name')
s = r2.cmdj('pfj.S @ 0x08')
print s
```

This script produces the following error :
```
$ python script.py 
r2pipe.cmdj.Error: Invalid control character at: line 1 column 63 (char 62)
None
```

The following script allows to display what the 'pf.S s name' command return : 
```
import r2pipe
r2 = r2pipe.open('/bin/ls')
r2.cmd('pf.S s name')
print r2.cmd('pfj.S @ 0x08')

$ python script2.py | hexdump -C
00000000  5b 7b 22 6e 61 6d 65 22  3a 22 6e 61 6d 65 22 2c  |[{"name":"name",|
00000010  22 74 79 70 65 22 3a 22  73 22 2c 22 6f 66 66 73  |"type":"s","offs|
00000020  65 74 22 3a 38 2c 22 76  61 6c 75 65 22 3a 38 2c  |et":8,"value":8,|
00000030  22 73 74 72 69 6e 67 22  3a 22 7f 45 4c 46 02 01  |"string":".ELF..|
00000040  01 22 7d 5d 0a                                    |."}].|
00000045
```
We can see that non printable characters are included in the json "\x7fELF\x02\x01\x01" and the json.loads() is not able to parse it. 

To allow non-printable characters to be parsed, the parameter strict needs to be set to False :
```
		data = json.loads(self.cmd(cmd).replace('\n', ''), strict=False)
```