### PR TITLE
Fixed 'TabError'

### DIFF
--- a/python/r2pipe/__init__.py
+++ b/python/r2pipe/__init__.py
@@ -38,9 +38,9 @@ try:
 except:
         r2lang = None
 try:
-	import fcntl
+        import fcntl
 except:
-	fcntl = None
+        fcntl = None
 try:
         from .native import RCore
         has_native = True
@@ -157,7 +157,7 @@ class open:
                                 raise Exception("ERROR: Cannot find radare2 in PATH")
                         self.process.stdout.read(1)  # Reads initial \x00
                         # make it non-blocking to speedup reading
-			self.nonblocking = False
+                        self.nonblocking = False
                         if fcntl is not None:
                                 self.nonblocking = True
                                 if self.nonblocking:


### PR DESCRIPTION
This commit fixes error:

/usr/bin/python3.6 setup.py build
Traceback (most recent call last):
  File "setup.py", line 2, in <module>
    import r2pipe
  File "/var/tmp/portage/dev-python/r2pipe-9999/work/r2pipe-9999/python/r2pipe/init.py", line 160
    self.nonblocking = False
                           ^
TabError: inconsistent use of tabs and spaces in indentation