### PR TITLE
python: added error handling where r_core library is not in path

### DIFF
--- a/python/r2pipe/native.py
+++ b/python/r2pipe/native.py
@@ -5,10 +5,14 @@ import sys
 from ctypes import CDLL, Structure, WinDLL, addressof, c_char_p, c_void_p
 from ctypes.util import find_library
 
+lib_name = find_library('r_core')
+if lib_name == None:
+	raise ImportError("No native r_core library")
+
 if sys.platform.startswith('win'):
-	lib = WinDLL(find_library('r_core'))
+	lib = WinDLL(lib_name)
 else:
-	lib = CDLL(find_library('r_core'))
+	lib = CDLL(lib_name)
 
 
 class AddressHolder(object):


### PR DESCRIPTION
In windows, when r_core is not accesible (ex. not in path) the installation fails because setup.py try to imports r2pipe and it generate the following execption:

  Using cached r2pipe-0.9.8.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "c:\users\$USER\appdata\local\temp\pip-build-f8_abq\r2pipe\setup.py", line 2, in <module>
        import r2pipe
      File "r2pipe\__init__.py", line 45, in <module>
        from .native import RCore
      File "r2pipe\native.py", line 9, in <module>
        lib = WinDLL(find_library('r_core'))
      File "C:\Python27\Lib\ctypes\__init__.py", line 365, in __init__
        self._handle = _dlopen(self._name, mode)
    TypeError: expected string or Unicode object, NoneType found

This is caused by find_library('r_core') that return None.