### PR TITLE
Handle JSON parse to work with iterator("@@")

### DIFF
--- a/nodejs/r2pipe/index.js
+++ b/nodejs/r2pipe/index.js
@@ -136,6 +136,9 @@ function parseJSON (func, cmd, callback) {
     if (res === '') {
       res = '{}';
     }
+    if (cmd.includes('@@')) {
+      res = res.replace(/\][\n]+\[/g,',');
+    }
     try {
       callback(null, r2node.jsonParse(res));
     } catch (e) {


### PR DESCRIPTION
Now it should work when parsing JSON object returned from an iterator for ex. 
```
r2.cmdj("pdj 1@@hit0");
```

This should be done in other bindings too (maybe I should open an issue).
I tried to write some test cases, but I'm more used to mocha and I couldn't make it work with the testsuite, anyways I'll try to add some test as soon as possible