### PR TITLE
Change `r2` to `radare2`, since meson doesn't make r2

### DIFF
--- a/c/README.md
+++ b/c/README.md
@@ -17,7 +17,7 @@ static void r2cmd(R2Pipe *r2, const char *cmd) {
 }
 
 int main() {
-	R2Pipe *r2 = r2p_open ("r2 -q0 /bin/ls");
+	R2Pipe *r2 = r2p_open ("radare2 -q0 /bin/ls");
 	if (r2) {
 		r2cmd (r2, "?e Hello World");
 		r2cmd (r2, "x");

--- a/c/test-pipe2.c
+++ b/c/test-pipe2.c
@@ -10,7 +10,7 @@ static void r2cmd(R2Pipe *r2, const char *cmd) {
 
 int main() {
 	// R2Pipe *r2 = r2p_open ("/bin/ls");
-	R2Pipe *r2 = r2p_open ("r2 -q0 /bin/ls");
+	R2Pipe *r2 = r2p_open ("radare2 -q0 /bin/ls");
 	if (r2) {
 		r2cmd (r2, "?e Hello World");
 		r2cmd (r2, "x");

--- a/c/test-spawn.c
+++ b/c/test-spawn.c
@@ -10,7 +10,7 @@ static void r2cmd(R2Pipe *r2, const char *cmd) {
 
 int main() {
 // XXX	R2Pipe *r2 = r2p_open ("/bin/ls");
-	R2Pipe *r2 = r2p_open ("r2 -q0 /bin/ls");
+	R2Pipe *r2 = r2p_open ("radare2 -q0 /bin/ls");
 	if (r2) {
 		r2cmd (r2, "?e Hello World");
 		r2cmd (r2, "x");

--- a/erlang/src/r2pipe.erl
+++ b/erlang/src/r2pipe.erl
@@ -8,28 +8,28 @@
 
 -export([init/1, init/2, init/3, cmd/2, cmdj/2, quit/0]).
 
-init(pipe, File) -> 
-	init(pipe, File, "r2").
+init(pipe, File) ->
+	init(pipe, File, "radare2").
 
-init(pipe, File, R2Bin) -> 
+init(pipe, File, R2Bin) ->
 	Path =  R2Bin ++ " -q0 " ++ File,
 	r2pipe_handler:start(Path),
 	{pipe, r2pipe_handler}.
 
-init(lpipe) -> 	
+init(lpipe) ->
 	r2pipe_handler:start(lpipe),
 	timer:sleep(50), %% ugly sleep to let i/o initialize
 	{pipe, r2pipe_handler}.
 
-cmd({pipe, _}, Cmd) -> 
+cmd({pipe, _}, Cmd) ->
 	{ok, Data} = r2pipe_handler:call(prepare_cmd(Cmd)),
 	binary_to_list(Data).
 
-cmdj({pipe, _}, Cmd) -> 
+cmdj({pipe, _}, Cmd) ->
 	{ok, Data} = r2pipe_handler:call(prepare_cmd(Cmd)),
 	parse_json(Data).
-	
-quit() -> 
+
+quit() ->
 	r2pipe_handler:stop().
 
 prepare_cmd(Cmd) ->

--- a/go/r2pipe.go
+++ b/go/r2pipe.go
@@ -98,7 +98,7 @@ func newPipeFd() (*Pipe, error) {
 }
 
 func newPipeCmd(file string) (*Pipe, error) {
-	r2cmd := exec.Command("r2", "-q0", file)
+	r2cmd := exec.Command("radare2", "-q0", file)
 	stdin, err := r2cmd.StdinPipe()
 	if err != nil {
 		return nil, err

--- a/haskell/R2pipe.hs
+++ b/haskell/R2pipe.hs
@@ -28,7 +28,7 @@ data R2Context = HttpCtx String
 open :: String -> IO R2Context
 open url@('h':'t':'t':'p':_) = return $ HttpCtx (url ++ "/cmd/")
 open filename = do
-    handles@(_, hOut, _, _) <- createProcess' $ proc "r2" ["-q0", filename]
+    handles@(_, hOut, _, _) <- createProcess' $ proc "radare2" ["-q0", filename]
     lHTakeWhile (/= 0) hOut -- drop the inital null that r2 emits
     return $ LocalCtx handles
 

--- a/newlisp/r2pipe.lsp
+++ b/newlisp/r2pipe.lsp
@@ -37,7 +37,7 @@
 (define (r2pipe-spawn:new filePath r2path)
 	(map set '(myin bcout) (pipe))
 	(map set '(bcin myout) (pipe))
-	(if (not r2path) (set 'r2path (first (exec "which r2"))))
+	(if (not r2path) (set 'r2path (first (exec "which radare2"))))
 	(set 'pid (process (string r2path " -q0 " filePath) bcin bcout))
 	;; XXX is this a bug in newLisp? process never returns -1
 	; (if (= -1 pid) (throw-error "Cannot spawn r2"))

--- a/ocaml/r2.ml
+++ b/ocaml/r2.ml
@@ -40,8 +40,8 @@ let open_file f_name =
         (out_r, out_w),
         (_, err_w) = Unix.(pipe (), pipe (), pipe ())
     in
-    let args = [|"r2"; "-2"; "-q0"; f_name|] in
-    let pid = Unix.create_process "r2" args ins_r out_w err_w in
+    let args = [|"radare2"; "-2"; "-q0"; f_name|] in
+    let pid = Unix.create_process "radare2" args ins_r out_w err_w in
     (* Get rid of the beginning \x00 *)
     ignore (Unix.read out_r (Bytes.create 1) 0 1);
     {pid; read_from = out_r; write_to = ins_w}

--- a/perl/lib/Radare/r2pipe.pm
+++ b/perl/lib/Radare/r2pipe.pm
@@ -44,7 +44,7 @@ sub parse_filename {
         $self->r2pipe_file($filename);
     }
     # So that open() knows if it's already opened a file
-    $self->{opened} = 1; 
+    $self->{opened} = 1;
 }
 
 sub r2pipe_http {
@@ -96,7 +96,7 @@ sub spawn_r2 {
     $self->{r2} = $r2pipe;
 
     # Spawn
-    $self->{r2}->spawn("r2 -q0 $file 2>/dev/null");
+    $self->{r2}->spawn("radare2 -q0 $file 2>/dev/null");
     $self->{r2}->read();
 }
 
@@ -199,7 +199,7 @@ sub quit_http {
     $self->{uri} = undef;
 }
 
-# Just for handiness sake. 
+# Just for handiness sake.
 sub close {
     my $self = shift;
     $self->quit();

--- a/php/poc.php
+++ b/php/poc.php
@@ -7,7 +7,7 @@ $descs = array(
 	1 => array("pipe", "w"),  // stdout
 	2 => array("pipe", "w")   // stderr
 );
-$proc = proc_open("r2 -q0 /bin/ls", $descs, $pipes);
+$proc = proc_open("radare2 -q0 /bin/ls", $descs, $pipes);
 if (is_resource($proc)) {
 	 $msg = fread($pipes[1], 1);
 }

--- a/python-async/examples/test-backends.py
+++ b/python-async/examples/test-backends.py
@@ -7,8 +7,8 @@ import time
 if __name__ == "__main__":
     print("[+] Spawning r2 tcp and http servers")
     system ("pkill r2")
-    system ("r2 -qc.:9080 /bin/ls &")
-    system ("r2 -qc=h /bin/ls &")
+    system ("radare2 -qc.:9080 /bin/ls &")
+    system ("radare2 -qc=h /bin/ls &")
     time.sleep(1)
 
     # Test r2pipe with local process
@@ -19,7 +19,7 @@ if __name__ == "__main__":
     info = rlocal.cmdj("ij")
     print ("Architecture: " + info['bin']['machine'])
 
-    # Test r2pipe with remote tcp process (launch it with "r2 -qc.:9080 myfile")
+    # Test r2pipe with remote tcp process (launch it with "radare2 -qc.:9080 myfile")
     print("[+] Testing python r2pipe tcp://")
     rremote = r2pipe.open("tcp://127.0.0.1:9080")
     disas = rremote.cmd("pi 5")
@@ -28,7 +28,7 @@ if __name__ == "__main__":
     else:
         print(disas)
 
-    # Test r2pipe with remote http process (launch it with "r2 -qc=H myfile")
+    # Test r2pipe with remote http process (launch it with "radare2 -qc=H myfile")
     print("[+] Testing python r2pipe http://")
     rremote = r2pipe.open("http://127.0.0.1:9090")
     disas = rremote.cmd("pi 5")

--- a/python-async/r2pipe/__init__.py
+++ b/python-async/r2pipe/__init__.py
@@ -58,8 +58,8 @@ if __name__ == "__main__":
 
 	print("[+] Spawning r2 tcp and http servers")
 	os.system("pkill r2")
-	os.system("r2 -qc.:9080 /bin/ls &")
-	os.system("r2 -qc=h /bin/ls &")
+	os.system("radare2 -qc.:9080 /bin/ls &")
+	os.system("radare2 -qc=h /bin/ls &")
 	time.sleep(1)
 
 	if sys.version_info <= (3, 0):
@@ -74,7 +74,7 @@ if __name__ == "__main__":
 		info = rlocal.cmdj("ij")
 		print("Architecture: " + info['bin']['machine'])
 
-		# Test r2pipe with remote tcp process (launch it with "r2 -qc.:9080 myfile")
+		# Test r2pipe with remote tcp process (launch it with "radare2 -qc.:9080 myfile")
 		print("[+] Testing python r2pipe tcp://")
 		rremote = open("tcp://127.0.0.1:9080")
 		disas = rremote.cmd("pi 5")
@@ -83,7 +83,7 @@ if __name__ == "__main__":
 		else:
 			print(disas)
 
-		# Test r2pipe with remote http process (launch it with "r2 -qc=H myfile")
+		# Test r2pipe with remote http process (launch it with "radare2 -qc=H myfile")
 		print("[+] Testing python r2pipe http://")
 		rremote = open("http://127.0.0.1:9090")
 		disas = rremote.cmd("pi 5")
@@ -119,7 +119,7 @@ if __name__ == "__main__":
 			rlocal.wait([t1, t2, t3])
 
 		#
-		# Test r2pipe with remote tcp process (launch it with "r2 -qc.:9080 myfile")
+		# Test r2pipe with remote tcp process (launch it with "radare2 -qc.:9080 myfile")
 		#
 		#   Start 1 task
 		print("[+] Testing python r2pipe tcp://")
@@ -138,7 +138,7 @@ if __name__ == "__main__":
 			rremote.wait([t1, t2, t3])
 
 		#
-		# Test r2pipe with remote http process (launch it with "r2 -qc=H myfile")
+		# Test r2pipe with remote http process (launch it with "radare2 -qc=H myfile")
 		#
 		print("[+] Testing python r2pipe http://")
 		rremote = open("tcp://127.0.0.1:9080")
@@ -155,4 +155,4 @@ if __name__ == "__main__":
 
 			rremote.wait([t1, t2, t3])
 
-	os.system("pkill -INT r2")
+	os.system("pkill -INT radare2")

--- a/python/examples/test-backends.py
+++ b/python/examples/test-backends.py
@@ -7,8 +7,8 @@ import time
 if __name__ == "__main__":
     print("[+] Spawning r2 tcp and http servers")
     system ("pkill r2")
-    system ("r2 -qc.:9080 /bin/ls &")
-    system ("r2 -qc=h /bin/ls &")
+    system ("radare2 -qc.:9080 /bin/ls &")
+    system ("radare2 -qc=h /bin/ls &")
     time.sleep(1)
 
     # Test r2pipe with local process
@@ -19,7 +19,7 @@ if __name__ == "__main__":
     info = rlocal.cmdj("ij")
     print ("Architecture: " + info['bin']['machine'])
 
-    # Test r2pipe with remote tcp process (launch it with "r2 -qc.:9080 myfile")
+    # Test r2pipe with remote tcp process (launch it with "radare2 -qc.:9080 myfile")
     print("[+] Testing python r2pipe tcp://")
     rremote = r2pipe.open("tcp://127.0.0.1:9080")
     disas = rremote.cmd("pi 5")
@@ -28,7 +28,7 @@ if __name__ == "__main__":
     else:
         print(disas)
 
-    # Test r2pipe with remote http process (launch it with "r2 -qc=H myfile")
+    # Test r2pipe with remote http process (launch it with "radare2 -qc=H myfile")
     print("[+] Testing python r2pipe http://")
     rremote = r2pipe.open("http://127.0.0.1:9090")
     disas = rremote.cmd("pi 5")

--- a/python/r2pipe/__init__.py
+++ b/python/r2pipe/__init__.py
@@ -47,7 +47,7 @@ else:
         urlopen = urllib2.urlopen
         URLError = urllib2.URLError
         from .open_sync import open
-         
+
 def version():
         """Return string with the version of the r2pipe library
         """
@@ -60,10 +60,10 @@ if __name__ == "__main__":
 
         print("[+] Spawning r2 tcp and http servers")
         os.system("pkill r2")
-        os.system("r2 -qc.:9080 /bin/ls &")
-        os.system("r2 -qc=h /bin/ls &")
+        os.system("radare2 -qc.:9080 /bin/ls &")
+        os.system("radare2 -qc=h /bin/ls &")
         time.sleep(1)
-        
+
         if sys.version_info <= (3, 0):
                 # Test r2pipe with local process
                 print("[+] Testing python r2pipe local")
@@ -73,7 +73,7 @@ if __name__ == "__main__":
                 info = rlocal.cmdj("ij")
                 print("Architecture: " + info['bin']['machine'])
 
-                # Test r2pipe with remote tcp process (launch it with "r2 -qc.:9080 myfile")
+                # Test r2pipe with remote tcp process (launch it with "radare2 -qc.:9080 myfile")
                 print("[+] Testing python r2pipe tcp://")
                 rremote = open("tcp://127.0.0.1:9080")
                 disas = rremote.cmd("pi 5")
@@ -82,7 +82,7 @@ if __name__ == "__main__":
                 else:
                         print(disas)
 
-                # Test r2pipe with remote http process (launch it with "r2 -qc=H myfile")
+                # Test r2pipe with remote http process (launch it with "radare2 -qc=H myfile")
                 print("[+] Testing python r2pipe http://")
                 rremote = open("http://127.0.0.1:9090")
                 disas = rremote.cmd("pi 5")
@@ -118,7 +118,7 @@ if __name__ == "__main__":
                         rlocall.wait([t1, t2, t3])
 
                 #
-                # Test r2pipe with remote tcp process (launch it with "r2 -qc.:9080 myfile")
+                # Test r2pipe with remote tcp process (launch it with "radare2 -qc.:9080 myfile")
                 #
                 #   Start 1 task
                 print("[+] Testing python r2pipe tcp://")
@@ -137,7 +137,7 @@ if __name__ == "__main__":
                         rremote.wait([t1, t2, t3])
 
                 #
-                # Test r2pipe with remote http process (launch it with "r2 -qc=H myfile")
+                # Test r2pipe with remote http process (launch it with "radare2 -qc=H myfile")
                 #
                 print("[+] Testing python r2pipe http://")
                 rremote = open("tcp://127.0.0.1:9080")
@@ -153,5 +153,5 @@ if __name__ == "__main__":
                         t3 = rremote.cmd("pi 5", callback=callback)
 
                         rremote.wait([t1, t2, t3])
-            
-        os.system("pkill -INT r2")
+
+        os.system("pkill -INT radare2")

--- a/ruby/r2pipe.rb
+++ b/ruby/r2pipe.rb
@@ -20,7 +20,7 @@ class R2Pipe
       @write = IO.new(fdOut, 'w')
       @pid = -1
     else
-      exec = "r2 -q0 #{Shellwords.shellescape file} 2>/dev/null"
+      exec = "radare2 -q0 #{Shellwords.shellescape file} 2>/dev/null"
       PTY.spawn(exec) do |read, write, pid|
         @read = read
         @write = write


### PR DESCRIPTION
I don't think this is an exhaustive change, since most of those were found just by grepping.