### PR TITLE
fixes #88: small update open_sync.py (remove utf-8 decodes)

### DIFF
--- a/python/r2pipe/open_sync.py
+++ b/python/r2pipe/open_sync.py
@@ -122,7 +122,7 @@ class open(OpenBase):
                                 if self.nonblocking:
                                         time.sleep(0.001)
 
-                return out.decode('utf8')
+                return out
 
         def _cmd_http(self, cmd):
                 try:
@@ -131,7 +131,7 @@ class open(OpenBase):
                         except:
                                 quocmd = urllib.quote(cmd)
                         response = urlopen('{uri}/{cmd}'.format(uri=self.uri, cmd=quocmd))
-                        return response.read().decode('utf-8')
+                        return response.read()
                 except URLError:
                          pass
                 return None
@@ -143,4 +143,4 @@ class open(OpenBase):
                 while data:
                         res += data
                         data = self.conn.recv(512)
-                return res.decode('utf-8')
+                return res


### PR DESCRIPTION
Hi! Please remove these decodes as sometimes the output isn't utf8-decodeable. 
https://user-images.githubusercontent.com/25626434/50499947-95937180-0a45-11e9-9607-2087a7aa73ad.png