### PR TITLE
[Perl] Fixed json trailing garbage + tcp multiple commands + updated docs

### DIFF
--- a/perl/t/readme_example.pl
+++ b/perl/t/readme_example.pl
@@ -1,0 +1,18 @@
+use Radare::r2pipe;
+use Data::Printer;
+
+my $r2 = Radare::r2pipe->new('/bin/ls');
+print "Information about the /bin/ls binary:\n";
+print $r2->cmd('iI');
+print "Information about the /bin/ls binary in JSON: ";
+print $r2->cmd('ij') . "\n";
+print "Information about the /bin/ls binary in a native Perl datastructure:\n";
+p $r2->cmdj('ij');
+$r2->quit();
+
+# Other stuff
+print "Opening /bin/ls with -A (analyze) flag.\n";
+$r2 = Radare::r2pipe->new(file => '/bin/ls', analyse => 1); # Opens r2 with -A option.
+print "Functions found in /bin/ls:\n";
+print $r2->cmd('afl') . "\n";
+$r2->close(); # Same as quit()

--- a/perl/t/test.pl
+++ b/perl/t/test.pl
@@ -1,26 +1,103 @@
+use strict;
+use warnings;
+
 use Radare::r2pipe;
+use Data::Printer;
 
-print "General functionality test...\n";
-my $r2pipe = Radare::r2pipe->new("/bin/ls");
-print $r2pipe->cmd("pi 10");
-print $r2pipe->cmd("iI");
-my $ds = $r2pipe->cmdj("ij");
-print "Architecture: " . $ds->{bin}->{machine} . "\n";
-$r2pipe->quit();
+my $filename = "/bin/ls";
 
-print "\n\nTesting open()...\n";
-my $o = Radare::r2pipe->new;
-$o->open("/bin/ls");
-print $o->cmd('iI');
-$o->quit();
+# Test just 1 parameter == file
+my $r1 = Radare::r2pipe->new($filename);
+print $r1->cmd('afl'); # Doesn't return anything because we haven't run analyse
+$r1->close();
 
-print "\n\nTesting TCP...\n";
-my $tcp = Radare::r2pipe->new("tcp://127.0.0.1:9080");
-print $tcp->cmd('pi 20') . "\n";
-$tcp->quit();
+print "press enter";
+<STDIN>;
 
-print "\n\nTesting HTTP...\n";
+# Test named parameter file
+my $r2 = Radare::r2pipe->new(file => $filename);
+$r2->close();
+$r2 = Radare::r2pipe->new(filename => $filename);
+$r2->quit();
+
+print "press enter";
+<STDIN>;
+
+# Test analyse
+my $r3 = Radare::r2pipe->new(file => $filename, analyse => 1);
+print "Executing 'afl', since 'analyse' option was given, this should print a list of found functions:\n";
+print $r3->cmd('afl');
+$r3->close();
+
+print "press enter";
+<STDIN>;
+
+# Test debugging
+my $r4 = Radare::r2pipe->new(file => $filename, debug => 1, analyse => 1);
+print "Showing location of main():\n";
+print $r4->cmd('? main~hex[1]');
+print "Setting breakpoint on main...\n";
+$r4->cmd('db main');
+print "Start execution from entry0...\n";
+print $r4->cmd('dc');
+print "We are now blocked at main...\n";
+print "Showing the memory map:\n";
+print $r4->cmd('dm');
+print "\n";
+print "Showing the RIP register value (should be equal to main() function):\n";
+print $r4->cmd('dr~rip');
+print "Continue with execution, should print list of files since we are executing /bin/ls:\n";
+print $r4->cmd('dc');
+$r4->close();
+
+print "press enter";
+<STDIN>;
+
+# Test writing
+my $r5 = Radare::r2pipe->new('file' => '-', writeable => 1);
+$r5->cmd('wx 909090');
+p $r5->cmd('px');
+$r5->close();
+
+print "press enter";
+<STDIN>;
+
+# Test removing null bytes at the end of output, this gave problems with json_decode
+# "garbage after JSON object, at character offset 686 ..."
+my $r6 = Radare::r2pipe->new($filename);
+my $ds = $r6->cmdj("ij");
+p $ds;
+
+print "press enter";
+<STDIN>;
+
+my $r7 = Radare::r2pipe->new($filename);
+print "General test: printing ten instructions:\n";
+print $r7->cmd("pi 10");
+print "General test: printing it as JSON:\n";
+print "Raw JSON: ";
+print $r7->cmd("pij 10"); print "\n";
+p $r7->cmdj("pij 10"); print "\n";
+
+print "press enter after opening r2 with HTTP interface: r2 -qc=H /bin/ls &\n";
+<STDIN>;
 my $http = Radare::r2pipe->new("http://127.0.0.1:9090");
-my $output = $http->cmd('pi 30');
-print "Output: $output\n";
+print "General test: printing ten instructions:\n";
+print $http->cmd('pi 10');
+print "General test: printing it as JSON:\n";
+print "Raw JSON: ";
+print $http->cmd("pij 10"); print "\n";
+p $http->cmdj("pij 10"); print "\n";
 $http->close();
+
+print "press enter after opening r2 with TCP interface: r2 -qc.:9080 /bin/ls &\n";
+<STDIN>;
+
+my $tcp = Radare::r2pipe->new("tcp://127.0.0.1:9080");
+print "General test: printing ten instructions:\n";
+print $tcp->cmd('pi 10') . "\n";
+print "General test: printing it as JSON:\n";
+print "Raw JSON: ";
+print $tcp->cmd("pij 10"); print "\n";
+p $tcp->cmdj("pij 10"); print "\n";
+$tcp->quit();


### PR DESCRIPTION
After using it, I noticed the following problems:

*JSON trailing garbage*:

```
[koffiedrinker@ctf perl]$ perl -MRadare::r2pipe -e 'my $r2pipe = Radare::r2pipe->new("/bin/ls");my $ds = $r2pipe->cmdj("ij");'
garbage after JSON object, at character offset 686 (before "(end of string)") at /usr/share/perl5/site_perl/Radare/r2pipe.pm line 134.
```

Fixed by removing null bytes at the end of the output before running it through json_decode():

```
$ perl -MRadare::r2pipe -MData::Printer -e 'my $r2pipe = Radare::r2pipe->new("/bin/ls");my $ds = $r2pipe->cmdj("ij");p $ds->{core}->{file}'
"/bin/ls"
```

Also, it seems that the *TCP socket is closed after sending 1 command* to it, so I reopen the socket before running each command to be sure it works (some tests with keepalive didn't go as planned).

This now works as expected:

```
my $tcp = Radare::r2pipe->new("tcp://127.0.0.1:9080");
print "General test: printing ten instructions:\n";
print $tcp->cmd('pi 10') . "\n";
print "General test: printing it as JSON:\n";
print "Raw JSON: ";
print $tcp->cmd("pij 10"); print "\n";
p $tcp->cmdj("pij 10"); print "\n";
$tcp->quit();
```

I've added the above to the `test.pl` script and generally added more "tests" (although it's more just sample code since it's not using Test::More package).

Added update to README as well as putting the readme code in `t/`.

All tested with:
```
$ r2 -v
radare2 3.2.0-git 73 @ linux-x86-64 git.3.2.0-git
commit: bd84d0a83dde10ffa9724a51f527ede3bbea11a6 build: 2019-01-05__01:11:21
```