### PR TITLE
handle arguments when passed with filename

### DIFF
--- a/python/r2pipe/open_sync.py
+++ b/python/r2pipe/open_sync.py
@@ -55,7 +55,13 @@ class open(OpenBase):
                                 # avoid errors on Windows when subprocess messes with name
                                 r2e += '.exe'
                         cmd = [r2e, "-q0", filename]
-                        cmd = cmd[:1] + flags + cmd[1:]
+                        if ' ' in filename:
+                            cmd = cmd[:1] + flags + cmd[1:-1] + [cmd[-1].split(' ')[0]]
+                            arguments = filename.split(' ')[1:]
+                            arguments = ['-Rarg'+str(x+1)+'='+arg for x,arg in enumerate(arguments)]
+                            cmd += arguments
+                        else:
+                            cmd = cmd[:1] + flags + cmd[1:]
                         try:
                                self.process = Popen(cmd, shell=False, stdin=PIPE, stdout=PIPE, bufsize=0)
                         except:


### PR DESCRIPTION
so if I do "filename arg1 arg2" it works as expected, this doesn't manage to work when there are spaces in filenames, but this is good since spaces in filenames are really bad practice XD