### PR TITLE
Update open_base.py to import Popen and PIPE

### DIFF
--- a/python/r2pipe/open_base.py
+++ b/python/r2pipe/open_base.py
@@ -12,6 +12,8 @@ import json
 import shutil
 import platform
 
+from subprocess import Popen, PIPE
+
 try:
 	import r2lang
 except ImportError:


### PR DESCRIPTION
Popen and PIPE are used in the file, but never imported.

Changed imports to reflect use.